### PR TITLE
Add minimumDistance as a parameter

### DIFF
--- a/InfinitePagingSample/InfinitePagingSample/ContentView.swift
+++ b/InfinitePagingSample/InfinitePagingSample/ContentView.swift
@@ -22,6 +22,7 @@ struct ContentView: View {
             InfinitePagingView(
                 objects: $pages,
                 pageAlignment: pageAlignment,
+                minimumDistance: 10,
                 pagingHandler: { pageDirection in
                     paging(pageDirection)
                 },

--- a/Sources/InfinitePaging/InfinitePagingView.swift
+++ b/Sources/InfinitePaging/InfinitePagingView.swift
@@ -11,6 +11,7 @@ public protocol Pageable: Equatable & Identifiable {}
 
 public struct InfinitePagingView<T: Pageable, Content: View>: View {
     @Binding var objects: [T]
+    private let minimumDistance: CGFloat
     let pageAlignment: PageAlignment
     let pagingHandler: (PageDirection) -> Void
     let content: (T) -> Content
@@ -18,11 +19,13 @@ public struct InfinitePagingView<T: Pageable, Content: View>: View {
     public init(
         objects: Binding<[T]>,
         pageAlignment: PageAlignment,
+        minimumDistance: CGFloat = 0,
         pagingHandler: @escaping (PageDirection) -> Void,
         @ViewBuilder content: @escaping (T) -> Content
     ) {
         assert(objects.wrappedValue.count == 3, "objects count must be 3.")
         _objects = objects
+        self.minimumDistance = minimumDistance
         self.pageAlignment = pageAlignment
         self.pagingHandler = pagingHandler
         self.content = content
@@ -45,6 +48,7 @@ public struct InfinitePagingView<T: Pageable, Content: View>: View {
                         get: { pageAlignment.scalar(proxy.size) },
                         set: { _ in }
                     ),
+                    minimumDistance: minimumDistance,
                     pageAlignment: pageAlignment,
                     pagingHandler: pagingHandler
                 )

--- a/Sources/InfinitePaging/InfinitePagingViewModifier.swift
+++ b/Sources/InfinitePaging/InfinitePagingViewModifier.swift
@@ -12,11 +12,12 @@ struct InfinitePagingViewModifier<T: Pageable>: ViewModifier {
     @Binding var pageSize: CGFloat
     @State var pagingOffset: CGFloat
     @State var draggingOffset: CGFloat
+    private let minimumDistance: CGFloat
     let pageAlignment: PageAlignment
     let pagingHandler: (PageDirection) -> Void
 
     var dragGesture: some Gesture {
-        DragGesture(minimumDistance: 0)
+        DragGesture(minimumDistance: minimumDistance)
             .onChanged { value in
                 draggingOffset = pageAlignment.scalar(value.translation)
             }
@@ -57,6 +58,7 @@ struct InfinitePagingViewModifier<T: Pageable>: ViewModifier {
     init(
         objects: Binding<[T]>,
         pageSize: Binding<CGFloat>,
+        minimumDistance: CGFloat,
         pageAlignment: PageAlignment,
         pagingHandler: @escaping (PageDirection) -> Void
     ) {
@@ -64,6 +66,7 @@ struct InfinitePagingViewModifier<T: Pageable>: ViewModifier {
         _pageSize = pageSize
         _pagingOffset = State(initialValue: -pageSize.wrappedValue)
         _draggingOffset = State(initialValue: 0)
+        self.minimumDistance = minimumDistance
         self.pageAlignment = pageAlignment
         self.pagingHandler = pagingHandler
     }


### PR DESCRIPTION
## Motivation.

- `DragGesture(minimumDistance: 0)` only tap responds to `.onChanged` of `DragGesture`.
  - When `Button` is placed inside of `InfinitePagingView`, it is complicated.

## Solution

- Change the minimumDistance externally, so that onChange does not work just by tapping.